### PR TITLE
refactor: the package names and the class names

### DIFF
--- a/.github/workflows/openai-review.yml
+++ b/.github/workflows/openai-review.yml
@@ -1,0 +1,35 @@
+name: OpenAI Reviewer
+permissions:
+  contents: read
+  pull-requests: write
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+concurrency:
+  group:
+    ${{ github.repository }}-${{ github.event.number || github.head_ref ||
+    github.sha }}-${{ github.workflow }}-${{ github.event_name ==
+    'pull_request_review_comment' && 'pr_comment' || 'pr' }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request_review_comment' }}
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{github.event.pull_request.head.ref}}
+          submodules: false
+      - uses: ./
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        with:
+          debug: true
+          review_comment_lgtm: false
+          openai_heavy_model: gpt-4
+          path_filters: |
+            !dist/**
+            !**/*.lock

--- a/src/main/java/com/github/j5ik2o/event/store/adapter/java/DefaultEventSerializer.java
+++ b/src/main/java/com/github/j5ik2o/event/store/adapter/java/DefaultEventSerializer.java
@@ -1,12 +1,11 @@
-package com.github.j5ik2o.event.store.adapter.java.internal;
+package com.github.j5ik2o.event.store.adapter.java;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.j5ik2o.event.store.adapter.java.*;
 import java.io.IOException;
 import javax.annotation.Nonnull;
 
-public final class JsonEventSerializer<AID extends AggregateId, E extends Event<AID>>
+public final class DefaultEventSerializer<AID extends AggregateId, E extends Event<AID>>
     implements EventSerializer<AID, E> {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -14,7 +13,7 @@ public final class JsonEventSerializer<AID extends AggregateId, E extends Event<
     objectMapper.findAndRegisterModules();
   }
 
-  public JsonEventSerializer() {}
+  public DefaultEventSerializer() {}
 
   @Nonnull
   @Override

--- a/src/main/java/com/github/j5ik2o/event/store/adapter/java/DefaultKeyResolver.java
+++ b/src/main/java/com/github/j5ik2o/event/store/adapter/java/DefaultKeyResolver.java
@@ -1,7 +1,5 @@
-package com.github.j5ik2o.event.store.adapter.java.internal;
+package com.github.j5ik2o.event.store.adapter.java;
 
-import com.github.j5ik2o.event.store.adapter.java.AggregateId;
-import com.github.j5ik2o.event.store.adapter.java.KeyResolver;
 import javax.annotation.Nonnull;
 
 public class DefaultKeyResolver<AID extends AggregateId> implements KeyResolver<AID> {

--- a/src/main/java/com/github/j5ik2o/event/store/adapter/java/DefaultSnapshotSerializer.java
+++ b/src/main/java/com/github/j5ik2o/event/store/adapter/java/DefaultSnapshotSerializer.java
@@ -1,12 +1,11 @@
-package com.github.j5ik2o.event.store.adapter.java.internal;
+package com.github.j5ik2o.event.store.adapter.java;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.j5ik2o.event.store.adapter.java.*;
 import java.io.IOException;
 import javax.annotation.Nonnull;
 
-public final class JsonSnapshotSerializer<AID extends AggregateId, A extends Aggregate<A, AID>>
+public final class DefaultSnapshotSerializer<AID extends AggregateId, A extends Aggregate<A, AID>>
     implements SnapshotSerializer<AID, A> {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -14,7 +13,7 @@ public final class JsonSnapshotSerializer<AID extends AggregateId, A extends Agg
     objectMapper.findAndRegisterModules();
   }
 
-  public JsonSnapshotSerializer() {}
+  public DefaultSnapshotSerializer() {}
 
   @Nonnull
   @Override

--- a/src/main/java/com/github/j5ik2o/event/store/adapter/java/internal/EventStoreAsyncForDynamoDB.java
+++ b/src/main/java/com/github/j5ik2o/event/store/adapter/java/internal/EventStoreAsyncForDynamoDB.java
@@ -113,8 +113,8 @@ public final class EventStoreAsyncForDynamoDB<
         null,
         null,
         new DefaultKeyResolver<>(),
-        new JsonEventSerializer<>(),
-        new JsonSnapshotSerializer<>());
+        new DefaultEventSerializer<>(),
+        new DefaultSnapshotSerializer<>());
   }
 
   @Nonnull

--- a/src/main/java/com/github/j5ik2o/event/store/adapter/java/internal/EventStoreForDynamoDB.java
+++ b/src/main/java/com/github/j5ik2o/event/store/adapter/java/internal/EventStoreForDynamoDB.java
@@ -112,8 +112,8 @@ public final class EventStoreForDynamoDB<
         null,
         null,
         new DefaultKeyResolver<>(),
-        new JsonEventSerializer<>(),
-        new JsonSnapshotSerializer<>());
+        new DefaultEventSerializer<>(),
+        new DefaultSnapshotSerializer<>());
   }
 
   @Nonnull


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Simplified the structure of the event store adapter by moving classes from the `internal` package to the main `java` package.
- Refactor: Renamed `JsonEventSerializer` to `DefaultEventSerializer` and `JsonSnapshotSerializer` to `DefaultSnapshotSerializer` for clarity and consistency.
- New Feature: Introduced a new GitHub Actions workflow, OpenAI Reviewer, to automate code reviews and improve code quality.

These changes streamline the codebase and enhance the automation of code reviews, but they do not directly impact end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->